### PR TITLE
update pin to 8.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d4da92ecd54d0f812d5161e6b06fc8578eb4b6c5641fcdc2d7d3dee1ba7e1463
 
 build:
-  number: 3
+  number: 4
   entry_points:
     - mayavi2 = mayavi.scripts.mayavi2:main
     - tvtk_doc = tvtk.tools.tvtk_doc:main
@@ -24,14 +24,14 @@ requirements:
     - python
     - numpy
     - setuptools
-    - vtk 8.1.*
+    - vtk 8.2.0
     - traitsui
     - apptools
     - sphinx  # [osx]
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - vtk 8.1.*
+    - vtk 8.2.0
     - traitsui
     - apptools
     - envisage


### PR DESCRIPTION
VTK 8.2.0 [does not appear to be ABI compatible](https://abi-laboratory.pro/index.php?view=timeline&l=vtk) with 8.1.*, so create a new build for it.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
