### PR TITLE
ENH: Remove local pin to VTK version

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -18,7 +18,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 target_platform:
 - linux-64
+vtk:
+- 8.2.0

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -18,7 +18,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 target_platform:
 - linux-64
+vtk:
+- 8.2.0

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -18,7 +18,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 target_platform:
 - linux-64
+vtk:
+- 8.2.0

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -11,11 +11,9 @@ channel_targets:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -20,7 +20,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 target_platform:
 - osx-64
+vtk:
+- 8.2.0

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -11,11 +11,9 @@ channel_targets:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -20,7 +20,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 target_platform:
 - osx-64
+vtk:
+- 8.2.0

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -11,11 +11,9 @@ channel_targets:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.5'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -20,7 +20,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 target_platform:
 - osx-64
+vtk:
+- 8.2.0

--- a/.ci_support/win_64_python3.6.____cpython.yaml
+++ b/.ci_support/win_64_python3.6.____cpython.yaml
@@ -14,7 +14,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 target_platform:
 - win-64
+vtk:
+- 8.2.0

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -14,7 +14,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 target_platform:
 - win-64
+vtk:
+- 8.2.0

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -14,7 +14,11 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
+  vtk:
+    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 target_platform:
 - win-64
+vtk:
+- 8.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - python
     - numpy
     - pip
-    - vtk >=8.2.0
+    - vtk
     - traitsui
     - apptools
     - sphinx  # [osx]
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - vtk >=8.2.0
+    - vtk
     - traitsui
     - pyface
     - apptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c8addff9c87c7b9f91d32205c99d0af75cf480cbb2585e69149ab6b9337deb2e
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - mayavi2 = mayavi.scripts.mayavi2:main
     - tvtk_doc = tvtk.tools.tvtk_doc:main
@@ -24,14 +24,14 @@ requirements:
     - python
     - numpy
     - pip
-    - vtk 8.2.0
+    - vtk >=8.2.0
     - traitsui
     - apptools
     - sphinx  # [osx]
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - vtk 8.2.0
+    - vtk >=8.2.0
     - traitsui
     - pyface
     - apptools


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Mayavi supports VTK9 (see https://github.com/enthought/mayavi/pull/909), update recipe to allow it -- I think this is what I'm doing anyway.

@grlee77 can you look to see if this makes sense? One problem is that we actually need different mayavi versions for different VTK versions. So somehow different ones need to be built for 8.2.0 and 9.0.1 (no need for 9.0.0 IMO). No idea if the stuff from #43 or #42 is also required for this...

Closes #43
Closes #42